### PR TITLE
Quick Add To Collection

### DIFF
--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -30,7 +30,7 @@
             <a class="button primary" href="place.html"> &#xFF0B; Location </a>
             <a class="button primary" href="person.html"> &#xFF0B; Person </a>
             <a class="button primary" href="object.html"> &#xFF0B; Object </a>
-            <a class="button secondary" href=""> &#xFF0B; Experience </a>
+            <a class="button primary" href="experience.html"> &#xFF0B; Experience </a>
         </div>
         <div>
             <!-- A kind of SPACE, OBJECT or BODY created by this user, ordered by most recent, clipped to a certain number perhaps -->
@@ -60,7 +60,7 @@
                     document.querySelector('.tabs').innerHTML += `<a href="users.html">Users</a>`
                     document.querySelector('.tabs').innerHTML += `<a href="all_experiences.html">Experiences</a>`
                 }
-                buttons+=`<a class="button secondary" href=""> &#xFF0B; Experience </a>`
+                buttons+=`<a class="button primary" href="experience.html"> &#xFF0B; Experience </a>`
                 document.querySelector('.entries').innerHTML = buttons
             }
             else{

--- a/web/experience.html
+++ b/web/experience.html
@@ -306,7 +306,7 @@
                     //FIXME if user is an administrator OR THE CREATOR OF THE EXPERIENCE
                     //How can I check if the logged in user is the creator of this experience (I have experience @id and user id).  
                     if (user.roles.administrator) {
-                        theExperience.setAttribute("deer-id", experienceID)
+                        theExperience.setAttribute("deer-id", expURI)
                         document.getElementById("startExperience").classList.add("is-hidden")
                         document.getElementById("experienceArtifacts").classList.remove("is-hidden")
                         document.getElementById("experienceReview").classList.remove("is-hidden")

--- a/web/experience.html
+++ b/web/experience.html
@@ -116,7 +116,7 @@
                     
                     <label> Select the Lived Religion researchers involved, if any. Hold <kbd>CTRL</kbd> to make multiple selections.  If you are an admin, you can create a new researcher with the &#x2b; below.</label>
                     <input deer-input-type="Set" type="hidden" deer-key="contributor" />
-                    <deer-view id="researchers" deer-collection="LivedReligionResearchersTest" deer-template="personMulti"></deer-view>
+                    <deer-view id="researchers" deer-collection="LivedReligionResearchersTest" deer-template="researcherMulti"></deer-view>
                     
                     <label> Select other people involved. Hold <kbd>CTRL</kbd> to make multiple selections. You may also create a new person with the &#x2b; below. </a> </label>
                     <input deer-input-type="Set" type="hidden" deer-key="attendee" />
@@ -124,7 +124,7 @@
                     
                     <label> Select any objects that were a part of the event. Hold <kbd>CTRL</kbd> to make multiple selections.  You may also create a new object with the &#x2b; below. </a> </label>
                     <input deer-input-type="Set" type="hidden" deer-key="object" />
-                    <deer-view id="objects" deer-collection="LivedReligionObjectsTest" deer-template="personMulti"></deer-view>
+                    <deer-view id="objects" deer-collection="LivedReligionObjectsTest" deer-template="objectMulti"></deer-view>
                     
                     <label>Provide a description of what prompted you to do this</label>
                     <textarea deer-key="description"></textarea>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -602,12 +602,13 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                         let multiSelect = event.target.closest("deer-view").querySelector("select[multiple]")
                         op.setAttribute("oninput", "LR.utils.handleMultiSelect(event,true)")
                         let delim = (input.hasAttribute("deer-array-delimeter")) ? input.getAttribute("deer-array-delimeter") : ","
-                        let tag = `<span class="tag is-small">${entity.label}</span>` 
+                        let tag = `<span class="tag is-small">${labelText}</span>` 
                         multiSelect.querySelector("optgroup").appendChild(op)
                         selectedTagsArea.innerHTML += tag
                         //op.click() does not work, so we have to produce the result programatically
                         input.value += (delim+newEntity.new_obj_state["@id"])
                     }
+                    LR.ui.globalFeedbackBlip(event, `Saving '${event.detail.name}' successful!`, true)
                 })
                 .catch(err =>{
                     alert("There was a problem trying to create the Annotation that puts the entity into the collection.  Please check the network panel.")

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -615,7 +615,7 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                         }
                         else{
                             //Blank or null.  This is the first value.  No delimeter.  
-                            input.value = (newEntity.new_obj_state["@id"])
+                            input.value = newEntity.new_obj_state["@id"]
                         }
                     }
                     //Give feedback

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -606,9 +606,18 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                         multiSelect.querySelector("optgroup").appendChild(op)
                         selectedTagsArea.innerHTML += tag
                         //op.click() does not work, so we have to produce the result programatically
-                        input.value += (delim+newEntity.new_obj_state["@id"])
+                        if(input.value){
+                            //There is already a string here, so we presume entries have already beed added.  Append, with delimiter.
+                            input.value += (delim+newEntity.new_obj_state["@id"])
+                        }
+                        else{
+                            //Blank or null.  This is the first value.  No delimeter.  
+                            input.value = (newEntity.new_obj_state["@id"])
+                        }
                     }
-                    LR.ui.globalFeedbackBlip(event, `Saving '${labelText}' successful!`, true)
+                    LR.ui.globalFeedbackBlip(event, `Added '${labelText}' successfully!`, true)
+                    //Now toggle hide this quick add area.
+                    event.target.parentElement.previousElementSibling.click()
                 })
                 .catch(err =>{
                     alert("There was a problem trying to create the Annotation that puts the entity into the collection.  Please check the network panel.")

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -524,8 +524,6 @@ LR.utils.saveFieldNotesInExperience = function(event){
  * @param {string} type The @type of the entity going into the collection
  */
 LR.utils.quicklyAddToCollection = async function(event, collectionName, selectedTagsArea, type){
-    //console.error("This functionality is not yet available.  Coming soon!")
-    //return false
     if(collectionName){
         let labelText = event.target.previousElementSibling.value
         let user = localStorage.getItem("lr-user")

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -526,7 +526,7 @@ LR.utils.saveFieldNotesInExperience = function(event){
  * @param {type} event
  * @return {undefined}
  */
-LR.utils.quicklyAddToCollection = async function(event, collectionName, selectedTagsArea){
+LR.utils.quicklyAddToCollection = async function(event, collectionName, selectedTagsArea, type){
     console.error("This functionality is not yet available.  Coming soon!")
     return false
     if(collectionName){
@@ -546,7 +546,7 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
         if(labelText){
             let entity = {
                 "@context" : LR.CONTEXT,
-                "type" : "Person",
+                "type" : type,
                 "name" : labelText
             }
             fetch(LR.URLS.CREATE, {
@@ -563,7 +563,7 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                     "@context" : LR.CONTEXT,
                     "body": {targetCollection: collectionName},
                     "target": newEntity["@id"],
-                    "creator": localStorage,
+                    "creator": userID,
                     "type": "Annotation"
                 }
                 fetch(LR.URLS.CREATE, {
@@ -576,11 +576,15 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                 })
                 .then(response => response.json())
                 .then(newAnno => {
+                    let multiSelect = event.target.closest("deer-view").querySelector("select[multiple]")
+                    let newOption = `<option class="deer-view" deer-template="label" deer-id="${entity["@id"]}" value="${entity["@id"]}"${entity.name}</option>`
                     let tag = `<span class="tag is-small">${entity.name}</span>` 
-                    selectedTagsArea.innerHTML += tag
-                    let input = event.target.closest("input[type='hidden']")
-                    let delim = (input.hasAttribute("deer-array-delimeter")) ? input.getAttribute("deer-array-delimeter") : ","
-                    input.value += (delim+entity.name)
+                    multiSelect.querySelector("optgroup").innerHTML += newOption
+                    //selectedTagsArea.innerHTML += tag
+                    newOption.click()
+//                    let input = event.target.closest("input[type='hidden']")
+//                    let delim = (input.hasAttribute("deer-array-delimeter")) ? input.getAttribute("deer-array-delimeter") : ","
+//                    input.value += (delim+entity.name)
                 })
                 .catch(err =>{
                     alert("There was a problem trying to create the Annotation that puts the entity into the collection.  Please check the network panel.")

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -517,8 +517,11 @@ LR.utils.saveFieldNotesInExperience = function(event){
 /**
  * Whenever a drop-down or multi-select is built from a collection, those views have to option to quickly add a new entity by label.
  * We need to take that label and make an entity for the collection by creating the new entity, then supplying the targetCollection annotation for it. 
- * @param {type} event
- * @return {undefined}
+ * Pagination must also occur, since reload() is not an option.  
+ * @param {type} event Event from clicking the 'Add' button
+ * @param {string} collectionName  Name of the collection this item is being added into
+ * @param {HTMLElement}  selectedTagsArea The area that the tag UI goes for showing selected items
+ * @param {string} type The @type of the entity going into the collection
  */
 LR.utils.quicklyAddToCollection = async function(event, collectionName, selectedTagsArea, type){
     //console.error("This functionality is not yet available.  Coming soon!")
@@ -583,9 +586,10 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                     op.setAttribute("deer-template", "label")
                     op.setAttribute("deer-id", newEntity.new_obj_state["@id"])
                     op.selected = true
+                    //op.click() does not work, so we have to produce the result programatically
                     let input = event.target.closest("deer-view").previousElementSibling
                     if(selectedTagsArea === null){
-                        //Then this is a dropdown, not a multi select, and there are no tags.  Deselect any selected option, then add this selected one in.
+                        //A dropdown, not a multi select, and there are no tags.  Deselect any selected option, then add this selected one in.
                         let dropdown = event.target.closest("deer-view").querySelector("select")
                         op.setAttribute("oninput", "this.parentElement.previousElementSibling.value=this.options[this.selectedIndex].value")
                         for ( let i = 0; i < dropdown.options.length; i++ ) {
@@ -595,6 +599,7 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                            }
                         }
                         dropdown.appendChild(op)
+                        //Write to deer-key input, as if that option had been clicked
                         input.value = newEntity.new_obj_state["@id"]
                     }
                     else{
@@ -605,7 +610,7 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                         let tag = `<span class="tag is-small">${labelText}</span>` 
                         multiSelect.querySelector("optgroup").appendChild(op)
                         selectedTagsArea.innerHTML += tag
-                        //op.click() does not work, so we have to produce the result programatically
+                        //Write to deer-key input, as if that option had been clicked
                         if(input.value){
                             //There is already a string here, so we presume entries have already beed added.  Append, with delimiter.
                             input.value += (delim+newEntity.new_obj_state["@id"])
@@ -615,6 +620,7 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                             input.value = (newEntity.new_obj_state["@id"])
                         }
                     }
+                    //Give feedback
                     LR.ui.globalFeedbackBlip(event, `Added '${labelText}' successfully!`, true)
                     //Now toggle hide this quick add area.
                     event.target.parentElement.previousElementSibling.click()
@@ -637,7 +643,6 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
     else{
         alert("The name of the collection to add to was not provided.  Check the button below and see if it knows the collection name or not.")
         console.warn("The name of the collection to add to was not provided.  Check the button below and see if it knows the collection name or not.")
-        console.log(event.target)
     }
 }
 

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -544,7 +544,7 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                 "type" : type,
                 "creator" : userID
             }
-            if(type === "person"){
+            if(type === "Person"){
                 entity.name = labelText
             }
             else{

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -608,7 +608,7 @@ LR.utils.quicklyAddToCollection = async function(event, collectionName, selected
                         //op.click() does not work, so we have to produce the result programatically
                         input.value += (delim+newEntity.new_obj_state["@id"])
                     }
-                    LR.ui.globalFeedbackBlip(event, `Saving '${event.detail.name}' successful!`, true)
+                    LR.ui.globalFeedbackBlip(event, `Saving '${labelText}' successful!`, true)
                 })
                 .catch(err =>{
                     alert("There was a problem trying to create the Annotation that puts the entity into the collection.  Please check the network panel.")

--- a/web/js/deerInitializer.js
+++ b/web/js/deerInitializer.js
@@ -82,7 +82,7 @@ DEER.TEMPLATES.locationsAsDropdown = function(obj, options = {}) {
         <div title="Quickly create a new entity for this collection by supplying a name or label." class="row quickAddEntity bg-light is-hidden">
             <span class="">Label:</span>
             <input class="bg-grey text-white" type="text" />
-            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling)">Add</a>
+            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling, 'Place')">Add</a>
         </div>`
         let tmpl = `<select class="locDropdown" oninput="this.parentElement.previousElementSibling.value=this.options[this.selectedIndex].value">`
         tmpl += `<option disabled selected value> Not Supplied </option>`
@@ -110,7 +110,7 @@ DEER.TEMPLATES.objectsAsDropdown = function(obj, options = {}) {
         <div title="Quickly create a new entity for this collection by supplying a name or label." class="row quickAddEntity bg-light is-hidden">
             <span class="">Label:</span>
             <input class="bg-grey text-white" type="text" />
-            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling)">Add</a>
+            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling, 'Thing')">Add</a>
         </div>`
         let tmpl = `<select class="objDropdown" oninput="this.parentElement.previousElementSibling.value=this.options[this.selectedIndex].value">`
         tmpl += `<option disabled selected value> Not Supplied </option>`
@@ -138,7 +138,7 @@ DEER.TEMPLATES.locationsMulti = function(obj, options = {}) {
         <div title="Quickly create a new entity for this collection by supplying a name or label." class="row quickAddEntity bg-light is-hidden">
             <span class="">Label:</span>
             <input class="bg-grey text-white" type="text" />
-            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling)">Add</a>
+            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling, 'Place')">Add</a>
         </div>`
         let selected = `<div class="row selectedEntities"></div>`
         let allLocationsInCollection = UTILS.getValue(obj.itemListElement)
@@ -168,7 +168,7 @@ DEER.TEMPLATES.personMulti = function(obj, options = {}) {
         <div title="Quickly create a new entity for this collection by supplying a name or label." class="row quickAddEntity bg-light is-hidden">
             <span class="">Name:</span>
             <input class="bg-grey text-white" type="text" />
-            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling)">Add</a>
+            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling, 'Person')">Add</a>
         </div>`
         let selected = `<div class="row selectedEntities"></div>`
         let allPeopleInCollection = UTILS.getValue(obj.itemListElement)
@@ -188,6 +188,33 @@ DEER.TEMPLATES.personMulti = function(obj, options = {}) {
 }
 
 /**
+ * Create a select area that is populated by some set or list of Researchers.
+ * These are different from a regular Person and are behind administrator privelages.  
+ * NO QUICK ADD TEMPLATE FOR THIS.  There is an admin interface for adding Researchers. 
+ * @param {type} obj
+ * @param {type} options
+ * @return {tmpl}
+ */
+DEER.TEMPLATES.researcherMulti = function(obj, options = {}) {
+    try {
+        let whichCollection = UTILS.getLabel(obj) ? UTILS.getLabel(obj) : ""
+        let selected = `<div class="row selectedEntities"></div>`
+        let allPeopleInCollection = UTILS.getValue(obj.itemListElement)
+        let tmpl = ``
+        tmpl += `<select multiple oninput="LR.utils.handleMultiSelect(event, true)">
+            <optgroup label="Choose Below"> `
+        for (let person of allPeopleInCollection) {
+            let name = UTILS.getLabel(person)
+            tmpl += `<option class="deer-view" deer-template="label" deer-id="${person['@id']}" value="${person['@id']}">${name}</option>`
+        }
+        tmpl += `</optgroup></select>${selected}`
+        return tmpl
+    } catch (err) {
+        return null
+    }
+}
+
+/**
  * Create a select area that is populated by some set or list of Objects.
  * @param {type} obj
  * @param {type} options
@@ -200,7 +227,7 @@ DEER.TEMPLATES.objectMulti = function(obj, options = {}) {
         <div title="Quickly create a new entity for this collection by supplying a name or label." class="row quickAddEntity bg-light is-hidden">
             <span class="">Label:</span>
             <input class="bg-grey text-white" type="text" />
-            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling)">Add</a>
+            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling, 'Thing')">Add</a>
         </div>`
         let selected = `<div class="row selectedEntities"></div>`
         let allObjectsInCollection = UTILS.getValue(obj.itemListElement)

--- a/web/js/deerInitializer.js
+++ b/web/js/deerInitializer.js
@@ -140,7 +140,7 @@ DEER.TEMPLATES.locationsMulti = function(obj, options = {}) {
             <input class="bg-grey text-white" type="text" />
             <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.closest('deer-view').querySelector('.selectedEntities'), 'Place')">Add</a>
         </div>`
-        let selected = `<div class="row selectedEntities"></div>`
+        let selected = `<div class="selectedEntities"></div>`
         let allLocationsInCollection = UTILS.getValue(obj.itemListElement)
         let tmpl = ``
         tmpl += `<select multiple oninput="LR.utils.handleMultiSelect(event,true)">
@@ -170,7 +170,7 @@ DEER.TEMPLATES.personMulti = function(obj, options = {}) {
             <input class="bg-grey text-white" type="text" />
             <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.closest('deer-view').querySelector('.selectedEntities'), 'Person')">Add</a>
         </div>`
-        let selected = `<div class="row selectedEntities"></div>`
+        let selected = `<div class="selectedEntities"></div>`
         let allPeopleInCollection = UTILS.getValue(obj.itemListElement)
         let tmpl = ``
         tmpl += `<select multiple oninput="LR.utils.handleMultiSelect(event, true)">
@@ -198,7 +198,7 @@ DEER.TEMPLATES.personMulti = function(obj, options = {}) {
 DEER.TEMPLATES.researcherMulti = function(obj, options = {}) {
     try {
         let whichCollection = UTILS.getLabel(obj) ? UTILS.getLabel(obj) : ""
-        let selected = `<div class="row selectedEntities"></div>`
+        let selected = `<div class="selectedEntities"></div>`
         let allPeopleInCollection = UTILS.getValue(obj.itemListElement)
         let tmpl = ``
         tmpl += `<select multiple oninput="LR.utils.handleMultiSelect(event, true)">
@@ -229,7 +229,7 @@ DEER.TEMPLATES.objectMulti = function(obj, options = {}) {
             <input class="bg-grey text-white" type="text" />
             <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.closest('deer-view').querySelector('.selectedEntities'), 'Thing')">Add</a>
         </div>`
-        let selected = `<div class="row selectedEntities"></div>`
+        let selected = `<div class="selectedEntities"></div>`
         let allObjectsInCollection = UTILS.getValue(obj.itemListElement)
         let tmpl = ``
         tmpl += `<select multiple oninput="LR.utils.handleMultiSelect(event, true)">

--- a/web/js/deerInitializer.js
+++ b/web/js/deerInitializer.js
@@ -82,7 +82,7 @@ DEER.TEMPLATES.locationsAsDropdown = function(obj, options = {}) {
         <div title="Quickly create a new entity for this collection by supplying a name or label." class="row quickAddEntity bg-light is-hidden">
             <span class="">Label:</span>
             <input class="bg-grey text-white" type="text" />
-            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling, 'Place')">Add</a>
+            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', null, 'Place')">Add</a>
         </div>`
         let tmpl = `<select class="locDropdown" oninput="this.parentElement.previousElementSibling.value=this.options[this.selectedIndex].value">`
         tmpl += `<option disabled selected value> Not Supplied </option>`
@@ -110,7 +110,7 @@ DEER.TEMPLATES.objectsAsDropdown = function(obj, options = {}) {
         <div title="Quickly create a new entity for this collection by supplying a name or label." class="row quickAddEntity bg-light is-hidden">
             <span class="">Label:</span>
             <input class="bg-grey text-white" type="text" />
-            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling, 'Thing')">Add</a>
+            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', null, 'Thing')">Add</a>
         </div>`
         let tmpl = `<select class="objDropdown" oninput="this.parentElement.previousElementSibling.value=this.options[this.selectedIndex].value">`
         tmpl += `<option disabled selected value> Not Supplied </option>`
@@ -138,7 +138,7 @@ DEER.TEMPLATES.locationsMulti = function(obj, options = {}) {
         <div title="Quickly create a new entity for this collection by supplying a name or label." class="row quickAddEntity bg-light is-hidden">
             <span class="">Label:</span>
             <input class="bg-grey text-white" type="text" />
-            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling, 'Place')">Add</a>
+            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.closest('deer-view').querySelector('.selectedEntities'), 'Place')">Add</a>
         </div>`
         let selected = `<div class="row selectedEntities"></div>`
         let allLocationsInCollection = UTILS.getValue(obj.itemListElement)
@@ -168,7 +168,7 @@ DEER.TEMPLATES.personMulti = function(obj, options = {}) {
         <div title="Quickly create a new entity for this collection by supplying a name or label." class="row quickAddEntity bg-light is-hidden">
             <span class="">Name:</span>
             <input class="bg-grey text-white" type="text" />
-            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling, 'Person')">Add</a>
+            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.closest('deer-view').querySelector('.selectedEntities'), 'Person')">Add</a>
         </div>`
         let selected = `<div class="row selectedEntities"></div>`
         let allPeopleInCollection = UTILS.getValue(obj.itemListElement)
@@ -227,7 +227,7 @@ DEER.TEMPLATES.objectMulti = function(obj, options = {}) {
         <div title="Quickly create a new entity for this collection by supplying a name or label." class="row quickAddEntity bg-light is-hidden">
             <span class="">Label:</span>
             <input class="bg-grey text-white" type="text" />
-            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.previousElementSibling, 'Thing')">Add</a>
+            <a class="tag bg-primary text-white is-small" onclick="LR.utils.quicklyAddToCollection(event, '${whichCollection}', this.closest('deer-view').querySelector('.selectedEntities'), 'Thing')">Add</a>
         </div>`
         let selected = `<div class="row selectedEntities"></div>`
         let allObjectsInCollection = UTILS.getValue(obj.itemListElement)

--- a/web/js/deerInitializer.js
+++ b/web/js/deerInitializer.js
@@ -190,7 +190,8 @@ DEER.TEMPLATES.personMulti = function(obj, options = {}) {
 /**
  * Create a select area that is populated by some set or list of Researchers.
  * These are different from a regular Person and are behind administrator privelages.  
- * NO QUICK ADD TEMPLATE FOR THIS.  There is an admin interface for adding Researchers. 
+ * NO QUICK ADD TEMPLATE FOR THIS.  There is only an admin interface for adding Researchers. 
+ * TODO allow admins to have a quick add interface for researchers?
  * @param {type} obj
  * @param {type} options
  * @return {tmpl}

--- a/web/researcher.html
+++ b/web/researcher.html
@@ -27,8 +27,9 @@
         <h2 class="text-primary">Create a New Researcher</h2>
         <div class="card bd-primary">
             <div class="card_body">
-                <form id="researcherForm" deer-creator deer-type="Researcher" deer-creator deer-motivation="supplementing" deer-context=http://store.rerum.io/context.json">
+                <form id="researcherForm" deer-creator deer-type="Person" deer-creator deer-motivation="supplementing" deer-context=http://store.rerum.io/context.json">
                     <input type="hidden" deer-key="creator" value="loading">
+                    <input type="hidden" deer-key="additionalType" value="Researcher">
                     <input type="hidden" deer-key="targetCollection" value="LivedReligionResearchersTest">
                     <div class="grouped">
                         <label>Name:</label>


### PR DESCRIPTION
Freshly merged in master, up on http://lived-religion-dev.rerum.io/deer-lr/experience.html for testing.  This is the UI and functionality for the "quick add" feature, allowing users to quickly add something to a collection by label in a data gathering interface (like the experience).  That way, they don't have to "go out and come back in", which is undesirable UX.

This was only lightly tested, and could use more testing.  However, these tests passed.

You will notice this functionality is not available to any user for `Researcher`s.  This is because `Researcher`s are strictly admin only, and so the admin interface is the only place to do it. 

